### PR TITLE
bin/test: simplify and add `set -euo pipefail`, so that it fails, when any test fails

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,17 +1,11 @@
 #!/usr/bin/env bash
 
-if [ -d ~/.vmodules/vnum ]; then
-    mv ~/.vmodules/vnum ~/.vmodules/old_vnum
-    rm -rf ~/.vmodules/vnum
-fi
+set -euo pipefail
 
-mkdir -p ~/.vmodules/vnum
-cp -r ./* ~/.vmodules/vnum
+rm -f vnum 
+ln -s . vnum
 
 v test .
-find . -name '*_test' -exec rm -f {} +
 
-rm -rf ~/.vmodules/vnum
-if [ -d ~/.vmodules/old_vnum ]; then
-    mv ~/.vmodules/old_vnum ~/.vmodules/vnum
-fi
+find . -name '*_test' -exec rm -f {} +
+rm -f vnum


### PR DESCRIPTION
Simplifies the test script, by making a symlink, instead of copying
everything into ~/.vmodules/ .

Adding `set -euo pipefail` makes the test script fail with exit code 1
when any of the commands in it fails (`v test .` fails when any of the
test assertions is false), in effect triggering a CI failure too =>
making the regression clear to the developer sooner.